### PR TITLE
ARES Offline Experience: Caching & Connectivity Fallback

### DIFF
--- a/orbitsounds/lib/models/playlist_model.dart
+++ b/orbitsounds/lib/models/playlist_model.dart
@@ -1,4 +1,4 @@
-import 'track_model.dart'; // 👈 importa el modelo Track
+playlist_model: import 'track_model.dart';
 
 class Playlist {
   final String id;
@@ -15,6 +15,7 @@ class Playlist {
     required this.tracks,
   });
 
+  /// ✔️ Para Firestore o APIs (tu versión original)
   Map<String, dynamic> toJson() => {
         "title": title,
         "description": description,
@@ -26,10 +27,33 @@ class Playlist {
               "durationMs": t.durationMs,
               "albumArt": t.albumArt,
               "previewUrl": t.previewUrl,
-              "isLiked": t.isLiked,       
+              "isLiked": t.isLiked,
             }).toList(),
       };
 
+  /// ✔️ NUEVO: Para Hive (usa Map en vez de JSON)
+  Map<String, dynamic> toMap() => {
+        "id": id,
+        "title": title,
+        "description": description,
+        "coverUrl": coverUrl,
+        "tracks": tracks.map((t) => t.toMap()).toList(),
+      };
+
+  /// ✔️ Constructor para Hive
+  factory Playlist.fromMap(Map<String, dynamic> map) {
+    return Playlist(
+      id: map["id"] ?? "",
+      title: map["title"] ?? "",
+      description: map["description"] ?? "",
+      coverUrl: map["coverUrl"] ?? "",
+      tracks: (map["tracks"] as List<dynamic>? ?? [])
+          .map((item) => Track.fromMap(Map<String, dynamic>.from(item)))
+          .toList(),
+    );
+  }
+
+  /// ✔️ Constructor para Firestore (tu original)
   factory Playlist.fromJson(String id, Map<String, dynamic> json) {
     return Playlist(
       id: id,

--- a/orbitsounds/lib/pages/ares_recommendations_screen.dart
+++ b/orbitsounds/lib/pages/ares_recommendations_screen.dart
@@ -1,4 +1,5 @@
-import 'dart:async';
+ares_recommendation_screen: import 'dart:async';
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:heroicons/heroicons.dart';
 import 'package:flutter_feather_icons/flutter_feather_icons.dart';
@@ -27,6 +28,15 @@ class _AresRecommendationsScreenState extends State<AresRecommendationsScreen> {
   List<String> _likedGenres = [];
   List<String> _interests = [];
 
+  Future<bool> hasInternetConnection() async {
+    try {
+      final result = await InternetAddress.lookup('example.com');
+      return result.isNotEmpty && result[0].rawAddress.isNotEmpty;
+    } catch (_) {
+      return false;
+    }
+  }
+
   Future<void> _generatePlaylist() async {
     await _progressSub?.cancel();
 
@@ -40,10 +50,32 @@ class _AresRecommendationsScreenState extends State<AresRecommendationsScreen> {
     });
 
     try {
+      final online = await hasInternetConnection();
+
+      if (!online) {
+        debugPrint("📴 No internet. Trying cache...");
+        final cached = await _ares.getCachedPlaylist(); // 👈 Debes tener esto
+        if (cached != null) {
+          setState(() {
+            _playlist = cached;
+            _loading = false;
+          });
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text("📴 No internet. Loaded cached ARES playlist."),
+              backgroundColor: Colors.orangeAccent,
+            ),
+          );
+          return;
+        } else {
+          throw Exception("No internet and no cached playlist available.");
+        }
+      }
+
+      // 🔹 Continúa con la generación normal
       final uid = FirebaseAuth.instance.currentUser?.uid;
       if (uid == null) throw Exception("User not authenticated");
 
-      // 🔹 Obtener documento del usuario
       final userDoc =
           await FirebaseFirestore.instance.collection('users').doc(uid).get();
       if (!userDoc.exists) throw Exception("User document not found");
@@ -51,7 +83,6 @@ class _AresRecommendationsScreenState extends State<AresRecommendationsScreen> {
       final userData = userDoc.data()!;
       _interests = List<String>.from(userData['interests'] ?? []);
 
-      // 🔹 Liked Songs
       final likedSongsSnap = await FirebaseFirestore.instance
           .collection('users')
           .doc(uid)
@@ -64,7 +95,6 @@ class _AresRecommendationsScreenState extends State<AresRecommendationsScreen> {
           .where((title) => title.isNotEmpty)
           .toList();
 
-      // 🔹 Favorite Genres (achieved == true)
       final goalsSnap = await FirebaseFirestore.instance
           .collection('users')
           .doc(uid)
@@ -77,7 +107,6 @@ class _AresRecommendationsScreenState extends State<AresRecommendationsScreen> {
           .where((g) => g.isNotEmpty)
           .toList();
 
-      // 🔹 Generar playlist personalizada
       final playlist = await _ares.generatePersonalizedPlaylist(
         likedGenres: _likedGenres,
         likedSongs: _likedSongs,
@@ -88,6 +117,9 @@ class _AresRecommendationsScreenState extends State<AresRecommendationsScreen> {
       setState(() {
         _playlist = playlist;
       });
+
+      // ✅ Guarda cache
+      await _ares.cachePlaylist(playlist!);
 
       await analytics.logEvent(
         name: 'ares_playlist_generated',
@@ -462,7 +494,7 @@ class _AresRecommendationsScreenState extends State<AresRecommendationsScreen> {
                                       width: 50,
                                       height: 50,
                                       fit: BoxFit.cover,
-                                      errorBuilder: (_, __, ___) => const Icon(
+                                      errorBuilder: (, _, _) => const Icon(
                                         Icons.broken_image,
                                         color: Color(0xFF8C1007),
                                       ),

--- a/orbitsounds/lib/services/ares_playlist_generator_service.dart
+++ b/orbitsounds/lib/services/ares_playlist_generator_service.dart
@@ -1,10 +1,11 @@
-import 'dart:async';
+ares_playlist_generator: import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:uuid/uuid.dart';
 import '../models/playlist_model.dart';
 import '../models/track_model.dart';
 import 'ares_service.dart';
 import 'spotify_service.dart';
+import 'package:hive/hive.dart';
 
 class AresPlaylistGeneratorService {
   final AresService _ares = AresService();
@@ -125,5 +126,26 @@ class AresPlaylistGeneratorService {
 
   void dispose() {
     _progressController.close();
+  }
+
+  /// 📦 Guarda la última playlist generada (cache offline)
+  Future<void> cachePlaylist(Playlist playlist) async {
+    final box = await Hive.openBox('trackCache');
+    await box.put('last_ares_playlist', playlist.toMap());
+    debugPrint("💾 Playlist cached");
+  }
+
+  /// 📦 Cargar playlist cacheada (cuando no hay internet)
+  Future<Playlist?> getCachedPlaylist() async {
+    final box = await Hive.openBox('trackCache');
+    final data = box.get('last_ares_playlist');
+    if (data == null) return null;
+
+    try {
+      return Playlist.fromMap(Map<String, dynamic>.from(data));
+    } catch (e) {
+      debugPrint("❌ Error reading cached playlist: $e");
+      return null;
+    }
   }
 }


### PR DESCRIPTION
## Overview
This PR introduces offline support for ARES recommendations by caching the last generated playlist locally and updating `AresRecommendationsScreen` to gracefully handle missing connectivity. It extends the Playlist model to support Map-based persistence (for Hive) and aligns the feature with the Sprint 4 quality scenarios (offline / eventual connectivity).

---

## Changes Included

- **AresPlaylistGeneratorService**
  - Added Hive dependency and a `trackCache` box usage.
  - Implemented `cachePlaylist(Playlist playlist)` to persist the last ARES playlist.
  - Implemented `getCachedPlaylist()` to restore a previously generated playlist from local storage.

- **Playlist model**
  - Kept existing `toJson` / `fromJson` behavior for Firestore.
  - Added `toMap()` and `fromMap()` to support local Map-based (Hive) serialization.
  - Integrated with `Track.toMap` / `Track.fromMap` for nested track lists.

- **AresRecommendationsScreen**
  - Added an internet connectivity check using `InternetAddress.lookup`.
  - Implemented an offline flow:
    - If there is no connection, tries to load `getCachedPlaylist()`.
    - If cache exists, uses it and shows a SnackBar: ` No internet. Loaded cached ARES playlist.`
    - If no cache is found, surfaces a clear error.
  - After a successful online generation, calls `await _ares.cachePlaylist(playlist!)` before analytics and usage updates.

---

## Behavior

### Online
- ARES generates a personalized playlist as before (Firestore + Ares + Spotify).
- After success, the playlist is cached via Hive.
- Analytics event `ares_playlist_generated` and `ares_usage_count` update remain unchanged.

### Offline
- AresRecommendationsScreen checks connectivity on `_generatePlaylist()`.
- If offline and a cached playlist exists:
  - The cached playlist is displayed.
  - A SnackBar notifies the user that a cached ARES playlist was loaded.
- If offline and no cache exists:
  - An error SnackBar is shown.
  - No crash and the screen remains responsive.

---

## Related Issues

Closes:
- #83 — Add Hive-based offline caching for ARES playlists  
- #84  — Extend Playlist model with toMap/fromMap  
- #85  — Handle offline mode in AresRecommendationsScreen  
- #86  — Cache latest ARES playlist after successful generation  
- #87 — Improve UX messaging for offline ARES recommendations

---

## Milestone

This PR is part of:

**Milestone: ARES Offline Experience & Caching (Sprint 4)**

---

## Testing

- Tested online flow with a valid user (Firestore user doc, liked songs, listening_goals).
- Tested offline mode:
  - With a previously generated playlist (cache hit).
  - With no cache (cache miss).
- Verified no crashes when network is unavailable.
- Confirmed that analytics and usage counters still work in the online flow.

---

## Notes

This work improves the resilience of ARES recommendations under poor connectivity and provides a better experience for users who reopen the app while offline. It also lays the foundation for future offline-first features.